### PR TITLE
Correction of hostname when no user domainname

### DIFF
--- a/templates/04-web.yaml
+++ b/templates/04-web.yaml
@@ -593,14 +593,15 @@ Resources:
                   'dbcollation' => 'utf8mb4_unicode_ci',
                 );
                 // Hostname definition //
-                $proto = 'https://';
                 $hostname = '${DomainName}';
                 if ($hostname == '') {
-                  $proto = 'http://';
-                  $hostname = '${PublicAlbHostname}';
+                  $hostwithprotocol = '${PublicAlbHostname}';
                 }
-                $CFG->wwwroot = $proto . strtolower($hostname);
-                $CFG->sslproxy = ($proto == 'https://' ? true : false);
+                else {
+                  $hostwithprotocol = ‘https://’ . strtolower($hostname);
+                }
+                $CFG->wwwroot = strtolower($hostwithprotocol);
+                $CFG->sslproxy = (substr($hostwithprotocol,0,5)==’https’ ? true : false);
                 // Moodledata location //
                 $CFG->dataroot = '/var/www/moodle/data';
                 $CFG->tempdir = '/var/www/moodle/temp';


### PR DESCRIPTION
§{PublicAlbHostname} already contains protocol (see outputs from 03-publicalb.yaml)

As defined today, the result of $proto . strtolower($hostname) is ‘http://http://monalb.region.elb.amazonaws.com’ resulting in a faulty configuration file and impossibility to connect. In fact, in 03-publicalb.yaml template, depending on existing sslcertificates or not, already indicates the protocol (http:// or https://).

