### PR TITLE
Fixed quotes in config.php template

### DIFF
--- a/templates/04-web.yaml
+++ b/templates/04-web.yaml
@@ -598,10 +598,10 @@ Resources:
                   $hostwithprotocol = '${PublicAlbHostname}';
                 }
                 else {
-                  $hostwithprotocol = ‘https://’ . strtolower($hostname);
+                  $hostwithprotocol = 'https://' . strtolower($hostname);
                 }
                 $CFG->wwwroot = strtolower($hostwithprotocol);
-                $CFG->sslproxy = (substr($hostwithprotocol,0,5)==’https’ ? true : false);
+                $CFG->sslproxy = (substr($hostwithprotocol,0,5)=='https' ? true : false);
                 // Moodledata location //
                 $CFG->dataroot = '/var/www/moodle/data';
                 $CFG->tempdir = '/var/www/moodle/temp';


### PR DESCRIPTION
*Issue #, if available:*

#4

*Description of changes:*

Fixes quote marks in 04-web.yaml. Previous quote marks (backticks) are replaced upon instantiation of the template by question marks, leading to an invalid PHP file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
