### PR TITLE
Update 03-rds.yaml

### DIFF
--- a/templates/03-rds.yaml
+++ b/templates/03-rds.yaml
@@ -150,7 +150,7 @@ Resources:
       DatabaseName: !Ref DatabaseName
       DBSubnetGroupName: !Ref DataSubnetGroup
       Engine: aurora-postgresql
-      DBClusterParameterGroupName: default.aurora-postgresql9.6
+      DBClusterParameterGroupName: default.aurora-postgresql10
       KmsKeyId:
         !If [ UseAWS-ManagedCMK, !Ref 'AWS::NoValue', !Ref DatabaseCmk ]
       MasterUsername: !Ref DatabaseMasterUsername


### PR DESCRIPTION


*Issue #, if available:*
Moodle CloudFormation template fails because the default version of the Postgresql engine is now 10 and not 9

*Description of changes:*
Changes to the parameter group to default to default.aurora-postgresql10, as the default engine version for aurora-postgresql is now 10.7 instead of 9.6.9

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
