### PR TITLE
fix: replaced EFS mount commands by /etc/fstab to avoid issues on instances reboot

### DIFF
--- a/templates/04-web.yaml
+++ b/templates/04-web.yaml
@@ -767,9 +767,10 @@ Resources:
             mkdir -p /var/www/moodle/local
             
             #Mount shared storage
-            mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 ${ElasticFileSystem}.efs.${AWS::Region}.amazonaws.com:/data /var/www/moodle/data
-            mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 ${ElasticFileSystem}.efs.${AWS::Region}.amazonaws.com:/cache /var/www/moodle/cache
-            mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 ${ElasticFileSystem}.efs.${AWS::Region}.amazonaws.com:/temp /var/www/moodle/temp
+            echo "${ElasticFileSystem}.efs.${AWS::Region}.amazonaws.com:/data /var/www/moodle/data nfs4 nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 0 0" >> /etc/fstab
+            echo "${ElasticFileSystem}.efs.${AWS::Region}.amazonaws.com:/cache /var/www/moodle/cache nfs4 nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 0 0" >> /etc/fstab
+            echo "${ElasticFileSystem}.efs.${AWS::Region}.amazonaws.com:/temp /var/www/moodle/temp nfs4 nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 0 0" >> /etc/fstab
+            mount -a
             
             #Run CloudFormation Init Scripts
             /opt/aws/bin/cfn-init --configsets deploy_webserver --verbose --stack ${AWS::StackName} --resource WebLaunchConfiguration --region ${AWS::Region}


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* The existing approach to mount EFS volumes stops work if instances get rebooted. This PR is replacing the existing mounting commands by the usage of /etc/fstab to be resilient on instances reboot.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
