### PR TITLE
changes needed for the template to work, because of recent updates to AWS

### DIFF
--- a/templates/03-efsfilesystem.yaml
+++ b/templates/03-efsfilesystem.yaml
@@ -528,7 +528,7 @@ Resources:
       FunctionName: !Join [ '', [ 'efs-', !Ref ElasticFileSystem, '-size-monitor' ] ]
       Handler: index.handler
       Role: !GetAtt LambdaRole.Arn
-      Runtime: python2.7
+      Runtime: python3.9
       Timeout: 60
   LambdaRole:
     Type: AWS::IAM::Role

--- a/templates/03-rds.yaml
+++ b/templates/03-rds.yaml
@@ -151,7 +151,7 @@ Resources:
       DatabaseName: !Ref DatabaseName
       DBSubnetGroupName: !Ref DataSubnetGroup
       Engine: aurora-postgresql
-      DBClusterParameterGroupName: default.aurora-postgresql11
+      DBClusterParameterGroupName: default.aurora-postgresql12
       KmsKeyId:
         !If [ UseAWS-ManagedCMK, !Ref 'AWS::NoValue', !Ref DatabaseCmk ]
       MasterUsername: !Join ['', ['{{resolve:secretsmanager:', !Ref MyRDSInstanceSecretArn, ':SecretString:username}}' ]]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changed the DBClusterParameterGroupName to default.aurora-postgresql12
and in the efs template, changed the lambda runtime to python3.9 (python2.7 is no longer supported)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
