### PR TITLE
Use libsodium-devel for php-sodium, Improve php memcached functionality

### DIFF
--- a/templates/04-web.yaml
+++ b/templates/04-web.yaml
@@ -446,13 +446,7 @@ Resources:
                 echo "extension=zip.so;" > /etc/php.d/50-zip.ini
 
                 # Install Sodium
-                dnf install -y gcc
-                wget https://download.libsodium.org/libsodium/releases/LATEST.tar.gz
-                tar -xvzf LATEST.tar.gz
-                cd libsodium-stable
-                ./configure
-                make
-                make install
+                dnf install -y libsodium-devel
                 pecl install -f libsodium
                 echo "extension=sodium.so;" > /etc/php.d/50-sodium.ini
 

--- a/templates/04-web.yaml
+++ b/templates/04-web.yaml
@@ -510,7 +510,8 @@ Resources:
                 #echo 'extension=amazon-elasticache-cluster-client.so;' > /etc/php.d/50-elasticache.ini
                 # Install Memcached client - note that ElastiCache client is failing on AL2023
                 dnf install libmemcached libmemcached-devel -y -q
-                /usr/bin/yes 'no' | pecl install memcached
+                dnf install -y zlib-devel cyrus-sasl-devel libevent-devel
+                /use/bin/yes 'no' | pecl install --configureoptions 'enable-memcached-igbinary="yes" enable-memcached-msgpack="yes" enable-memcached-json="yes" enable-memcached-protocol="yes" enable-memcached-sasl="yes" enable-memcached-session="yes"' memcached
                 echo 'extension=memcached.so' > /etc/php.d/41-memcached.ini
 
                 # Mount EFS

--- a/templates/04-web.yaml
+++ b/templates/04-web.yaml
@@ -511,7 +511,7 @@ Resources:
                 # Install Memcached client - note that ElastiCache client is failing on AL2023
                 dnf install libmemcached libmemcached-devel -y -q
                 dnf install -y zlib-devel cyrus-sasl-devel libevent-devel
-                /use/bin/yes 'no' | pecl install --configureoptions 'enable-memcached-igbinary="yes" enable-memcached-msgpack="yes" enable-memcached-json="yes" enable-memcached-protocol="yes" enable-memcached-sasl="yes" enable-memcached-session="yes"' memcached
+                /usr/bin/yes 'no' | pecl install --configureoptions 'enable-memcached-igbinary="yes" enable-memcached-msgpack="yes" enable-memcached-json="yes" enable-memcached-protocol="yes" enable-memcached-sasl="yes" enable-memcached-session="yes"' memcached
                 echo 'extension=memcached.so' > /etc/php.d/41-memcached.ini
 
                 # Mount EFS


### PR DESCRIPTION
*Issue #, if available:*
Original code download and compile libsodium source codes.
libsodium has been released as part of AL2023.2 (https://github.com/amazonlinux/amazon-linux-2023/issues/377)

*Description of changes:*
Use libsodium-devel to build php-sodium

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
